### PR TITLE
Build before publish

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -16,6 +16,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
           scope: "@pkic"
       - run: npm ci
+      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The dist directory was not included because the package was not build:

![image](https://github.com/user-attachments/assets/0e981e30-16b2-48b2-991e-dada6d59f3a3)
